### PR TITLE
Add option support to async helpers

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -382,7 +382,15 @@ ExpressHbs.prototype.compile = function(source, filename) {
  * @param {String} fn The `function(options, cb)`
  */
 ExpressHbs.prototype.registerAsyncHelper = function(name, fn) {
-  this.handlebars.registerHelper(name, function(context) {
+  this.handlebars.registerHelper(name, function(context, options) {
+    if (options && fn.length > 2) {
+      var resolver = function(arr, cb) {
+        return fn.call(this, arr[0], arr[1], cb);
+      };
+
+      return async.resolve(resolver.bind(this), [context, options]);
+    }
+
     return async.resolve(fn.bind(this), context);
   });
 };

--- a/test/issues.js
+++ b/test/issues.js
@@ -311,6 +311,63 @@ describe('issue-73', function() {
 });
 
 
+describe('issue-62', function() {
+  var dirname =  path.join(__dirname, 'issues/62');
 
+  it('should provide options for async helpers', function(done) {
+    var hb = hbs.create();
 
+    function async(c, o, cb) {
+      if (o.hash.type === 'em') {
+        cb('<em>' + c + '</em>');
+      } else {
+        cb('<strong>' + c + '</strong>');
+      }
+    }
 
+    hb.registerAsyncHelper("async", async);
+
+    var render = hb.express3({
+      viewsDir: dirname
+    });
+    var locals = H.createLocals('express3', dirname);
+
+    render(dirname + '/basic.hbs', locals, function (err, html) {
+      assert.equal(
+        H.stripWs(html),
+        '&lt;strong&gt;foo&lt;/strong&gt;&lt;em&gt;foo&lt;/em&gt;'
+      );
+      done();
+    });
+  });
+
+  it('should allow for block async helpers', function(done) {
+    var hb = hbs.create();
+
+    function async(c, o, cb) {
+      var self = this;
+      self.output = c;
+
+      if (o.hash.inverse === 'true') {
+        cb(o.inverse(self));
+      } else {
+        cb(o.fn(self));
+      }
+    }
+
+    hb.registerAsyncHelper("async", async);
+
+    var render = hb.express3({
+      viewsDir: dirname
+    });
+    var locals = H.createLocals('express3', dirname);
+
+    render(dirname + '/block.hbs', locals, function (err, html) {
+      assert.equal(
+        H.stripWs(html),
+        '<p>GoodbyeWorld</p><p>HelloHandlebars</p>'
+      );
+      done();
+    });
+  });
+});

--- a/test/issues/62/basic.hbs
+++ b/test/issues/62/basic.hbs
@@ -1,0 +1,2 @@
+{{async "foo"}}
+{{async "foo" type="em"}}

--- a/test/issues/62/block.hbs
+++ b/test/issues/62/block.hbs
@@ -1,0 +1,11 @@
+{{#async "World" inverse="true"}}
+    <p>Hello {{output}}</p>
+{{else}}
+    <p>Goodbye {{output}}</p>
+{{/async}}
+
+{{#async "Handlebars" inverse="false"}}
+    <p>Hello {{output}}</p>
+{{else}}
+    <p>Goodbye {{output}}</p>
+{{/async}}


### PR DESCRIPTION
I've been trying to fix #62 as we need that functionality in Ghost. I can fix it by doing an override of registerAsyncHelper locally, but I also found this way to update the existing code to support both the existing version which assumes there is only context, and support helpers which also provide options.

Not sure if my approach is ideal though, so thought I'd raise it as a PR here and get some feedback. If the approach is good then I'll add some tests.