### PR TITLE
Default to empty string for viewsDir

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -369,7 +369,7 @@ ExpressHbs.prototype.compile = function(source, filename) {
     if (Array.isArray(this.viewsDir) && this.viewsDir.length > 0) {
       compiled.__filename = path.relative(this.cwd, filename).replace(path.sep, '/');
     } else {
-      compiled.__filename = path.relative(this.viewsDir, filename).replace(path.sep, '/');
+      compiled.__filename = path.relative(this.viewsDir || '', filename).replace(path.sep, '/');
     }
   }
   return compiled;

--- a/test/issues.js
+++ b/test/issues.js
@@ -370,4 +370,22 @@ describe('issue-62', function() {
       done();
     });
   });
+
+  describe('issue-76', function() {
+    var dirname =  path.join(__dirname, 'issues/76');
+
+    it('should allow cachePartials to be called independently of render', function (done) {
+      var hb = hbs.create();
+
+      var render = hb.express3({
+        partialsDir: dirname
+      });
+
+      hbs.cachePartials(function (err) {
+        assert.ifError(err);
+        assert.ok(true);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
fixes #76 

This works and includes a test that fails without the fallback. Not sure if this is really the right solution, but here it is just in case :)