### PR TITLE
Supporting nested contentFor.

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -49,7 +49,7 @@ ExpressHbs.prototype.block = function(name) {
  */
 ExpressHbs.prototype.content = function(name, options, context) {
   var block = this.blocks[name] || (this.blocks[name] = []);
-  block.push(options.fn(context));
+  block.unshift(options.fn(context));
 };
 
 /**


### PR DESCRIPTION
When using contentFor in nested partials and templates, the order of the replaced blocks seems to be reversed from what it should be.
