### PR TITLE
Windows partial name fix

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -180,6 +180,8 @@ ExpressHbs.prototype.cachePartials = function(cb) {
       dirname = dirname === '.' ? '' : dirname + '/';
 
       var name = dirname + path.basename(entry.name, path.extname(entry.name));
+      // fix the path in windows
+      name = name.split('\\').join('/');
       self.registerPartial(name, source, entry.fullPath);
     })
     .on('end', function() {


### PR DESCRIPTION
Windows has a problem resolving subdirectory names in the partials. Usually the subdirectories will end up with partial names like these:
parentDir\childDir/partial

By replacing the backslashes in the partials, we can have clean names and have the ability to resolve sub-directory partials.

closes #84 