### PR TITLE
fix for 'undefined' error when options.settings is null when renderin…

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -444,7 +444,14 @@ ExpressHbs.prototype.___express = function ___express(filename, source, options,
     source = null;
   }
 
-  this.viewsDir = options.settings.views || this.viewsDirOpt;
+
+  if (options.settings) {
+    this.viewsDir = options.settings.views || this.viewsDirOpt;
+  }
+  else {
+    this.viewsDir = this.viewsDirOpt;
+  }
+  
   var self = this;
 
   /**


### PR DESCRIPTION
In express 4, the options.settings variable is not defined for a normal call to:

`res.render('index', { title: 'Hello'});`

In this scenario, line 447 would return an undefined error for options.settings.views and crash the application.
