### PR TITLE
Update Handlebars dependency to version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "i18n": "~0.4.1"
   },
   "dependencies": {
-    "handlebars": "^3.0.0",
+    "handlebars": "^4.0.0",
     "js-beautify": "1.5.4",
     "readdirp": "~1.3.0"
   }


### PR DESCRIPTION
* Handlebars `< 4.0` shipped with a version of `uglify-js` that has some issues. Upgrading to 4 brings in a fixed version of `uglify-js`.
