### PR TITLE
Upgraded readdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "handlebars": "^4.0.5",
     "js-beautify": "1.5.4",
-    "readdirp": "~1.3.0"
+    "readdirp": "~1.4.0"
   }
 }


### PR DESCRIPTION
Fixes #94.  Verified tests passing and usage in our app is as expected (no more Node v6.0.0 warnings, functioning as expected)