### PR TITLE
Upgrade all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "cookie-parser": "~1.3.3",
-    "express": "~4.11.2",
+    "express": "4.14.0",
     "grunt": "~0.4.1",
     "grunt-mocha-cli": "~1.12.0",
     "grunt-release": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-mocha-cli": "~1.12.0",
     "grunt-release": "^0.13.1",
     "i18n": "0.8.3",
-    "mocha": "~2.1.0",
+    "mocha": "3.0.2",
     "rewire": "2.5.2",
     "supertest": "2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-release": "^0.13.1",
     "i18n": "~0.4.1",
     "mocha": "~2.1.0",
-    "rewire": "~2.2.0",
+    "rewire": "2.5.2",
     "supertest": "~0.15.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Mario Gutierrez <mario@barc.com>",
   "license": "MIT",
   "devDependencies": {
-    "cookie-parser": "~1.3.3",
+    "cookie-parser": "1.4.3",
     "express": "4.14.0",
     "grunt": "~0.4.1",
     "grunt-mocha-cli": "~1.12.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "~0.4.1",
     "grunt-mocha-cli": "~1.12.0",
     "grunt-release": "^0.13.1",
-    "i18n": "~0.4.1",
+    "i18n": "0.8.3",
     "mocha": "~2.1.0",
     "rewire": "2.5.2",
     "supertest": "~0.15.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "handlebars": "^4.0.5",
-    "js-beautify": "1.5.4",
+    "js-beautify": "1.6.4",
     "readdirp": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "devDependencies": {
     "cookie-parser": "1.4.3",
     "express": "4.14.0",
-    "grunt": "~0.4.1",
-    "grunt-mocha-cli": "~1.12.0",
-    "grunt-release": "^0.13.1",
+    "grunt": "1.0.1",
+    "grunt-mocha-cli": "2.1.0",
+    "grunt-release": "0.14.0",
     "i18n": "0.8.3",
     "mocha": "3.0.2",
     "rewire": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "i18n": "0.8.3",
     "mocha": "~2.1.0",
     "rewire": "2.5.2",
-    "supertest": "~0.15.0"
+    "supertest": "2.0.0"
   },
   "dependencies": {
     "handlebars": "^4.0.5",


### PR DESCRIPTION
Now that https://github.com/beautify-web/js-beautify/issues/900 is merged, we are able to update js-beautify. 

In addition, this PR updates every dev dependency, which were, with the exception of `grunt-release` all to provide tests. The tests are all still running.

We'll see if `grunt-release` still works shortly after this is added in!