### PR TITLE
fix cachePartials extension name

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -179,7 +179,7 @@ ExpressHbs.prototype.cachePartials = function(cb) {
       var dirname = path.dirname(entry.path);
       dirname = dirname === '.' ? '' : dirname + '/';
 
-      var name = dirname + path.basename(entry.name, path.extname(entry.name));
+      var name = dirname + path.basename(entry.name, self._options.extname);
       // fix the path in windows
       name = name.split('\\').join('/');
       self.registerPartial(name, source, entry.fullPath);

--- a/test/customExtension.js
+++ b/test/customExtension.js
@@ -1,0 +1,35 @@
+'use strict';
+var assert = require('assert');
+var hbs = require('..');
+var path = require('path');
+var H = require('./helpers');
+
+
+// MEANJS is using custom extension .server.view.html instead of .hbs 
+// https://github.com/meanjs/mean
+describe('custom extension for partials view', function() {
+  var dirname = path.join(__dirname, 'views/customExtension');
+  var render = hbs.create().express4({
+      extname: '.server.view.html',
+      partialsDir: dirname + '/partialsDir'
+  });
+
+  it('should allow rendering multiple partials with custom extension', function(done) {
+    function check(err, html) {
+      assert.ifError(err);
+      assert.equal(
+        '<html>' + 
+          '<subpartial>1</subpartial>' + 
+          '<partial>1</partial>' + 
+          '<subpartial>2</subpartial>' + 
+          '<partial>2</partial>' + 
+        '</html>', 
+      H.stripWs(html));
+      done();
+    }
+
+    var options = {cache: true, settings: {views: dirname }};
+    render(dirname + '/template.server.view.html', options, check);
+  });
+
+});

--- a/test/views/customExtension/layout.server.view.html
+++ b/test/views/customExtension/layout.server.view.html
@@ -1,0 +1,1 @@
+<html>{{{body}}}</html>

--- a/test/views/customExtension/partialsDir/partial1.server.view.html
+++ b/test/views/customExtension/partialsDir/partial1.server.view.html
@@ -1,0 +1,1 @@
+<partial>1</partial>

--- a/test/views/customExtension/partialsDir/partial2.server.view.html
+++ b/test/views/customExtension/partialsDir/partial2.server.view.html
@@ -1,0 +1,1 @@
+<partial>2</partial>

--- a/test/views/customExtension/partialsDir/subs/subPartial1.server.view.html
+++ b/test/views/customExtension/partialsDir/subs/subPartial1.server.view.html
@@ -1,0 +1,1 @@
+<subpartial>1</subpartial>

--- a/test/views/customExtension/partialsDir/subs/subPartial2.server.view.html
+++ b/test/views/customExtension/partialsDir/subs/subPartial2.server.view.html
@@ -1,0 +1,1 @@
+<subpartial>2</subpartial>

--- a/test/views/customExtension/template.server.view.html
+++ b/test/views/customExtension/template.server.view.html
@@ -1,0 +1,5 @@
+{{!< layout}}
+{{> subs/subPartial1}}
+{{> partial1}}
+{{> subs/subPartial2}}
+{{> partial2}}


### PR DESCRIPTION
fix multi-dotted extension name usage for partials in [meanjs](https://github.com/meanjs/mean) 
```js
{
...
extname: '.server.view.html'
...
}
```