### PR TITLE
Multiple response data accumulated

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -31,11 +31,11 @@ var ExpressHbs = function() {
  *
  *  {{{block "pageStylesheets"}}}
  */
-ExpressHbs.prototype.block = function(name) {
-  var val = (this.blocks[name] || []).join('\n');
-  // free mem
-  this.blocks[name] = null;
-  return val;
+ExpressHbs.prototype.block = function(name, options, context) {
+  if (context._handlebarsBlockVars && context._handlebarsBlockVars[name]) {
+    return context._handlebarsBlockVars[name].join('\n');
+  }
+  return '';
 };
 
 /**
@@ -48,7 +48,8 @@ ExpressHbs.prototype.block = function(name) {
  * {{/contentFor}}
  */
 ExpressHbs.prototype.content = function(name, options, context) {
-  var block = this.blocks[name] || (this.blocks[name] = []);
+  context._handlebarsBlockVars = context._handlebarsBlockVars || {};
+  var block = context._handlebarsBlockVars[name] || (context._handlebarsBlockVars[name] = []);
   block.push(options.fn(context));
 };
 
@@ -247,7 +248,7 @@ ExpressHbs.prototype.express3 = function(options) {
   }
 
   this.handlebars.registerHelper(this._options.blockHelperName, function(name, options) {
-    var val = self.block(name);
+    var val = self.block(name, options, this);
     if (val === '' && typeof options.fn === 'function') {
       val = options.fn(this);
     }
@@ -280,10 +281,6 @@ ExpressHbs.prototype.express3 = function(options) {
 
   // Cache for templates, express 3.x doesn't do this for us
   this.cache = {};
-
-  // Blocks for layouts. Is this safe? What happens if the same block is used on multiple connections?
-  // Isn't there a chance block and content  are not in sync. The template and layout are processed asynchronously.
-  this.blocks = {};
 
   // Holds the default compiled layout if specified in options configuration.
   this.defaultLayoutTemplates = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-hbs",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Express 3 handlebars template engine complete with multiple layouts, partials and blocks.",
   "keywords": [
     "express3",


### PR DESCRIPTION
If the block helper is not called, it will accumulate and flush all at once.

```
{{#if enableHeader}}
<header class="ly-header header headroom">
  <div class="">
    <div class="head head-left">
      {{{block "headLeft"}}}
    </div>
    <div class="head-center">
      <h1 class="tit truncate">{{{block "headTitle"}}}</h1>
    </div>
    <div class="head head-right">
      {{{block "headRight"}}}
    </div>
  </div>
  {{{block "headGnb"}}}
</header>
{{/if}}
```