### PR TITLE
Joining block contents with newline

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -233,9 +233,12 @@ ExpressHbs.prototype.express3 = function(options) {
   }
 
   this.handlebars.registerHelper(this._options.blockHelperName, function(name, options) {
-    var val = options.data.root.blockCache[name].join('\n');
+    var val = options.data.root.blockCache[name];
     if (val === undefined && typeof options.fn === 'function') {
       val = options.fn(this);
+    }
+    if (Array.isArray(val)) {
+      val = val.join('\n'); 
     }
     return val;
   });

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -233,7 +233,7 @@ ExpressHbs.prototype.express3 = function(options) {
   }
 
   this.handlebars.registerHelper(this._options.blockHelperName, function(name, options) {
-    var val = options.data.root.blockCache[name];
+    var val = options.data.root.blockCache[name].join('\n');
     if (val === undefined && typeof options.fn === 'function') {
       val = options.fn(this);
     }

--- a/test/issues.js
+++ b/test/issues.js
@@ -429,3 +429,20 @@ describe('issue-144', function() {
     });
   });
 });
+
+describe('issue-153', function() {
+  var dirname = path.join(__dirname, 'issues/153');
+  it('should concat contentFor blocks with newline', function(done) {
+    var check = function (err, html) {
+      if (err) {
+        done(err);
+      }
+      assert.equal('1\n2', html.trim());
+      done();
+    }
+    var hb = hbs.create()
+    var render = hb.express3({});
+    var locals = H.createLocals('express3', dirname, { });
+    render(dirname + '/index.hbs', locals, check);
+  });
+});

--- a/test/issues/153/index.hbs
+++ b/test/issues/153/index.hbs
@@ -1,0 +1,3 @@
+{{#contentFor "testBlock"}}1{{/contentFor}}
+{{#contentFor "testBlock"}}2{{/contentFor}}
+{{{block "testBlock"}}}


### PR DESCRIPTION
Current version joins block contents with a comma, should be with a newline.